### PR TITLE
Set media_address when EXTERNAL_ADDRESS is defined

### DIFF
--- a/etc/asterisk/pjsip.conf.j2
+++ b/etc/asterisk/pjsip.conf.j2
@@ -13,6 +13,7 @@ local_net={{ local_net}}
 {% if EXTERNAL_ADDRESS is defined -%}
 external_media_address={{ EXTERNAL_ADDRESS }}
 external_signaling_address={{ EXTERNAL_ADDRESS }}
+media_address={{ EXTERNAL_ADDRESS }}
 {% endif -%}
 
 #tryinclude "verboice/*.conf"


### PR DESCRIPTION
It's needed to set the correct public IP in the `o=` line of the SIP INVITE - which some providers ask for.

Fixes instedd/verboice#877