### PR TITLE
Revert "Set media_address when EXTERNAL_ADDRESS is defined (#1)"

### DIFF
--- a/etc/asterisk/pjsip.conf.j2
+++ b/etc/asterisk/pjsip.conf.j2
@@ -13,7 +13,6 @@ local_net={{ local_net}}
 {% if EXTERNAL_ADDRESS is defined -%}
 external_media_address={{ EXTERNAL_ADDRESS }}
 external_signaling_address={{ EXTERNAL_ADDRESS }}
-media_address={{ EXTERNAL_ADDRESS }}
 {% endif -%}
 
 #tryinclude "verboice/*.conf"


### PR DESCRIPTION
The `media_address` setting belongs to the individual endpoints instead of the `transport` - where we were adding it.

I've yet to find how to properly add it. In the mean time, let's revert the change to avoid asterisk erroring while trying to parse the default configuration.

This reverts commit d9517b5c235c0d22b0310cd4c8f5c33c0f13f1d7 (#1).